### PR TITLE
Make rayon optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   allow_failures:
     - rust: nightly
 env:
-  - FEATURES=""
+  - FEATURES="rayon"
 script:
   - cargo build --verbose --no-default-features --features "$FEATURES" &&
     cargo test --verbose --no-default-features --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   allow_failures:
     - rust: nightly
 env:
+  - FEATURES=""
   - FEATURES="rayon"
 script:
   - cargo build --verbose --no-default-features --features "$FEATURES" &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,13 @@ exclude = ["tests/*"]
 
 [dependencies]
 byteorder = "0.5"
-rayon = "0.5"
+
+[dependencies.rayon]
+version = "0.5"
+optional = true
+
+[features]
+default = ["rayon"]
 
 [dev-dependencies]
 walkdir = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate byteorder;
+#[cfg(feature="rayon")]
 extern crate rayon;
 
 pub use decoder::{Decoder, ImageInfo, PixelFormat};


### PR DESCRIPTION
This allows compilation on systems that do not currently support `rayon` or its dependencies, such as Redox