### PR TITLE
Allow nightly builds to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: rust
 rust:
+  - 1.12.0
   - stable
+  - beta
   - nightly
 os:
   - linux
   - osx
+matrix:
+  allow_failures:
+    - rust: nightly
+env:
+  - FEATURES=""
+script:
+  - cargo build --verbose --no-default-features --features "$FEATURES" &&
+    cargo test --verbose --no-default-features --features "$FEATURES"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - TARGET: x86_64-pc-windows-msvc
-  - TARGET: i686-pc-windows-msvc
-  - TARGET: i686-pc-windows-gnu
+    - TARGET: x86_64-pc-windows-msvc
+    - TARGET: i686-pc-windows-msvc
+    - TARGET: i686-pc-windows-gnu
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
@@ -15,4 +15,5 @@ install:
 build: false
 
 test_script:
+  - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
Start testing on the minimum supported rust version and beta and prepare a feature matrix