### PR TITLE
Bump Rayon to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests/*"]
 byteorder = "0.5"
 
 [dependencies.rayon]
-version = "0.5"
+version = "0.6"
 optional = true
 
 [features]


### PR DESCRIPTION
Servo needs to update to rayon 0.6, and jpeg-decoder is currently the only dependency it has that currently requires 0.5. Would you mind doing a quick release to unblock us?

CC @nikomatsakis @metajack @larsbergstrom @emilio @SimonSapin