### PR TITLE
Use rayon's `par_chunks_mut`

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -781,21 +781,19 @@ fn compute_image_parallel(components: &[Component],
                  output_size: Dimensions,
                  is_jfif: bool,
                  color_transform: Option<AdobeColorTransform>) -> Result<Vec<u8>> {
-    use rayon::iter::*;
+    use rayon::prelude::*;
 
     let color_convert_func = try!(choose_color_convert_func(components.len(), is_jfif, color_transform));
     let upsampler = try!(Upsampler::new(components, output_size.width, output_size.height));
     let line_size = output_size.width as usize * components.len();
     let mut image = vec![0u8; line_size * output_size.height as usize];
 
-    image.chunks_mut(line_size)
-         .collect::<Vec<&mut [u8]>>()
-         .par_iter_mut()
+    image.par_chunks_mut(line_size)
          .with_max_len(1)
          .enumerate()
          .for_each(|(row, line)| {
-             upsampler.upsample_and_interleave_row(data, row, output_size.width as usize, *line);
-             color_convert_func(*line, output_size.width as usize);
+             upsampler.upsample_and_interleave_row(data, row, output_size.width as usize, line);
+             color_convert_func(line, output_size.width as usize);
          });
 
     Ok(image)
@@ -813,11 +811,9 @@ fn compute_image_parallel(components: &[Component],
     let mut image = vec![0u8; line_size * output_size.height as usize];
 
     for (row, line) in image.chunks_mut(line_size)
-         .collect::<Vec<&mut [u8]>>()
-         .iter_mut()
          .enumerate() {
-             upsampler.upsample_and_interleave_row(data, row, output_size.width as usize, *line);
-             color_convert_func(*line, output_size.width as usize);
+             upsampler.upsample_and_interleave_row(data, row, output_size.width as usize, line);
+             color_convert_func(line, output_size.width as usize);
          }
 
     Ok(image)


### PR DESCRIPTION
In `compute_image_parallel`, there's no need to collect `chunks_mut`
into a vector when rayon can iterate `par_chunks_mut` directly.  The
non-rayon version also doesn't need an intermediate vector.