### PR TITLE
Bump minimum supported rust version to 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.13.0
+  - 1.14.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Recently published `flate2` 0.2.20 doesn't compile with rust 1.13.