### PR TITLE
Revert "Needless clone and pass by value"

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -460,7 +460,7 @@ impl<R: Read> Decoder<R> {
                                          &mut huffman,
                                          self.dc_huffman_tables[scan.dc_table_indices[i]].as_ref(),
                                          self.ac_huffman_tables[scan.ac_table_indices[i]].as_ref(),
-                                         &scan.spectral_selection,
+                                         scan.spectral_selection.clone(),
                                          scan.successive_approximation_low,
                                          &mut eob_run,
                                          &mut dc_predictors[i])?;
@@ -547,7 +547,7 @@ fn decode_block<R: Read>(reader: &mut R,
                          huffman: &mut HuffmanDecoder,
                          dc_table: Option<&HuffmanTable>,
                          ac_table: Option<&HuffmanTable>,
-                         spectral_selection: &Range<u8>,
+                         spectral_selection: Range<u8>,
                          successive_approximation_low: u8,
                          eob_run: &mut u16,
                          dc_predictor: &mut i16) -> Result<()> {


### PR DESCRIPTION
Reverts kaksmet/jpeg-decoder#82

In practice cloning it or passing it by reference won't matter here and the patch just changed `decode_block`, while `decode_block_successive_approximation` still took spectral_selection by value.