### PR TITLE
Require rust >= 1.28 [fixes CI]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.24.1
+  - 1.28.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ fn main() {
     let metadata = decoder.info().unwrap();
 }
 ```
+
+## Requirements
+This crate compiles only with rust >= 1.28.


### PR DESCRIPTION
This implements option number 1 of #102. 

Fixes #102 